### PR TITLE
Handle allocation failures in framebuffer creation

### DIFF
--- a/renderer/framebuffer.c
+++ b/renderer/framebuffer.c
@@ -4,9 +4,19 @@
 
 framebuffer* fb_create(int w, int h){
     framebuffer* fb = malloc(sizeof(framebuffer));
+    if (!fb) return NULL;
     fb->w = w; fb->h = h;
     fb->color = malloc(sizeof(uint32_t)*w*h);
+    if (!fb->color){
+        free(fb);
+        return NULL;
+    }
     fb->depth = malloc(sizeof(float)*w*h);
+    if (!fb->depth){
+        free(fb->color);
+        free(fb);
+        return NULL;
+    }
     return fb;
 }
 


### PR DESCRIPTION
## Summary
- Add NULL checks after each malloc in `fb_create` and free previously allocated memory on failure

## Testing
- `gcc -c renderer/framebuffer.c -I. -std=c17`
- `gcc main.c math/vec.c renderer/framebuffer.c renderer/line.c -I. -lSDL2 -lm -o cad_wireframe` *(fails: SDL2/SDL.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68aa992f41b8832eadec80972b8ee499