### PR TITLE
Handle zero-length vectors in normalization

### DIFF
--- a/math/vec.c
+++ b/math/vec.c
@@ -13,5 +13,8 @@ vec3 vec3_cross(vec3 a, vec3 b){
 float vec3_dot(vec3 a, vec3 b){ return a.x*b.x + a.y*b.y + a.z*b.z; }
 vec3 vec3_norm(vec3 v){
     float l = sqrtf(vec3_dot(v,v));
+    if(l == 0.0f){
+        return (vec3){0.0f, 0.0f, 0.0f};
+    }
     return (vec3){v.x/l, v.y/l, v.z/l};
 }


### PR DESCRIPTION
## Summary
- prevent division by zero in `vec3_norm` by returning a zero vector when the length is zero

## Testing
- `gcc -std=c99 -Wall -Wextra -pedantic -c math/vec.c`


------
https://chatgpt.com/codex/tasks/task_e_68aa9acd2a14832ea7a449050572423c