### PR TITLE
Include stdlib for abs in line renderer

### DIFF
--- a/renderer/line.c
+++ b/renderer/line.c
@@ -1,3 +1,4 @@
+#include <stdlib.h>
 #include "framebuffer.h"
 
 void draw_line(framebuffer* fb, int x0, int y0, int x1, int y1, uint32_t color){


### PR DESCRIPTION
## Summary
- include `<stdlib.h>` in `renderer/line.c` so that `abs` is declared

## Testing
- `gcc main.c math/vec.c renderer/framebuffer.c renderer/line.c -I. -lSDL2 -lm -o cad_wireframe` *(fails: SDL2/SDL.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68aa9b6df13c832e9d5533d1583f5b7e